### PR TITLE
Remove Webmin key, not used for Virtualmin installs anymore

### DIFF
--- a/rpmbuild/SPECS/virtualmin-gpl-release.spec
+++ b/rpmbuild/SPECS/virtualmin-gpl-release.spec
@@ -2,12 +2,11 @@
 
 Summary: Virtualmin release file and package configuration for Virtualmin GPL
 Name: virtualmin-gpl-release
-Version: 7.0
+Version: 7.1
 Release: 1
-License: Copyright 2005-2022 Virtualmin, Inc.
+License: Copyright 2005-2024 Virtualmin, Inc.
 Group: System Environment/Base
-Source0: RPM-GPG-KEY-webmin
-Source1: RPM-GPG-KEY-virtualmin-7
+Source0: RPM-GPG-KEY-virtualmin-7
 Source10: virtualmin.repo-gpl
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch
@@ -15,8 +14,7 @@ BuildArch: noarch
 %description
 Virtualmin release file. This package also contains yum configuration to
 use the virtualmin.com provided rpm packages, as well as the public gpg key
-used to sign them.  It also installs the Webmin public key, so automatic
-upgrades of Webmin from webmin.com will have valid keys.
+used to sign them.
 
 
 %prep
@@ -27,11 +25,9 @@ upgrades of Webmin from webmin.com will have valid keys.
 
 %install
 %{__rm} -rf %{buildroot}
-%{__cp} -a %{SOURCE0} %{SOURCE1} .
-# Install gpg public keys
+%{__cp} -a %{SOURCE0} .
+# Install gpg public key
 %{__install} -D -p -m 0644 %{SOURCE0} \
-    %{buildroot}%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-webmin
-%{__install} -D -p -m 0644 %{SOURCE1} \
     %{buildroot}%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-virtualmin-7
 # Install yum repo file
 %{__install} -D -p -m 0644 %{SOURCE10} \
@@ -45,10 +41,7 @@ upgrades of Webmin from webmin.com will have valid keys.
 %post
 # Hopefully, only run this if this is our first installation
 if [ "$1" -eq 1 ]; then
-  # Import Jamie's gpg key if needed
-  rpm -q gpg-pubkey-11f63c51-3c7dc11d >/dev/null 2>&1 || \
-    rpm --import %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-webmin
-  # Import the Virtualmin 6.0 official gpg key if needed
+  # Import the Virtualmin 7 official gpg key if needed
   rpm -q gpg-pubkey-9d3152d3-895093ac >/dev/null 2>&1 || \
     rpm --import %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-virtualmin-7
 fi
@@ -58,15 +51,15 @@ exit 0
 
 
 %files
-%defattr(-, root, root, 0755)
-%pubkey RPM-GPG-KEY-webmin
+%defattr(-, root, root, 0644)
 %pubkey RPM-GPG-KEY-virtualmin-7
-%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-webmin
 %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-virtualmin-7
 %attr(0640,root,root) %config(noreplace) %{_sysconfdir}/yum.repos.d/virtualmin.repo
 
 
 %changelog
+* Thu Oct 31 2024 Joe Cooper <joe@virtualmin.com>
+- Remove Webmin key. Virtualmin users have no business there.
 * Thu Oct 31 2024 Joe Cooper <joe@virtualmin.com>
 - Fix perms
 * Sun May 15 2022 Joe Cooper <joe@virtualmin.com>

--- a/rpmbuild/SPECS/virtualmin-pro-release.spec
+++ b/rpmbuild/SPECS/virtualmin-pro-release.spec
@@ -2,12 +2,11 @@
 
 Summary: Virtualmin release file and package configuration for Virtualmin GPL
 Name: virtualmin-pro-release
-Version: 7.0
+Version: 7.1
 Release: 1
-License: Copyright 2005-2022 Virtualmin, Inc.
+License: Copyright 2005-2024 Virtualmin, Inc.
 Group: System Environment/Base
-Source0: RPM-GPG-KEY-webmin
-Source1: RPM-GPG-KEY-virtualmin-7
+Source0: RPM-GPG-KEY-virtualmin-7
 Source10: virtualmin.repo
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch
@@ -15,8 +14,7 @@ BuildArch: noarch
 %description
 Virtualmin release file. This package also contains yum configuration to
 use the virtualmin.com provided rpm packages, as well as the public gpg key
-used to sign them.  It also installs the Webmin public key, so automatic
-upgrades of Webmin from webmin.com will have valid keys.
+used to sign them.
 
 
 %prep
@@ -27,10 +25,8 @@ upgrades of Webmin from webmin.com will have valid keys.
 
 %install
 %{__rm} -rf %{buildroot}
-%{__cp} -a %{SOURCE0} %{SOURCE1} .
+%{__cp} -a %{SOURCE0} .
 # Install gpg public keys
-%{__install} -D -p -m 0644 %{SOURCE0} \
-    %{buildroot}%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-webmin
 %{__install} -D -p -m 0644 %{SOURCE1} \
     %{buildroot}%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-virtualmin-7
 # Install yum repo file
@@ -45,9 +41,6 @@ upgrades of Webmin from webmin.com will have valid keys.
 %post
 # Hopefully, only run this if this is our first installation
 if [ "$1" -eq 1 ]; then
-  # Import Jamie's gpg key if needed
-  rpm -q gpg-pubkey-11f63c51-3c7dc11d >/dev/null 2>&1 || \
-    rpm --import %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-webmin
   # Import the Virtualmin 6.0 official gpg key if needed
   rpm -q gpg-pubkey-9d3152d3-895093ac >/dev/null 2>&1 || \
     rpm --import %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-virtualmin-7
@@ -64,15 +57,15 @@ exit 0
 
 
 %files
-%defattr(-, root, root, 0755)
-%pubkey RPM-GPG-KEY-webmin
+%defattr(-, root, root, 0644)
 %pubkey RPM-GPG-KEY-virtualmin-7
-%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-webmin
 %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-virtualmin-7
 %attr(0640,root,root) %config(noreplace) %{_sysconfdir}/yum.repos.d/virtualmin.repo
 
 
 %changelog
+* Thu Oct 31 2024 Joe Cooper <joe@virtualmin.com>
+- Remove Webmin key. Virtualmin users have no business there.
 * Thu Oct 31 2024 Joe Cooper <joe@virtualmin.com>
 - Fix perms
 * Sun May 15 2022 Joe Cooper <joe@virtualmin.com>

--- a/rpmbuild/SPECS/virtualmin-pro-release.spec
+++ b/rpmbuild/SPECS/virtualmin-pro-release.spec
@@ -26,7 +26,7 @@ used to sign them.
 %install
 %{__rm} -rf %{buildroot}
 %{__cp} -a %{SOURCE0} .
-# Install gpg public keys
+# Install gpg public key
 %{__install} -D -p -m 0644 %{SOURCE1} \
     %{buildroot}%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-virtualmin-7
 # Install yum repo file
@@ -41,7 +41,7 @@ used to sign them.
 %post
 # Hopefully, only run this if this is our first installation
 if [ "$1" -eq 1 ]; then
-  # Import the Virtualmin 6.0 official gpg key if needed
+  # Import the Virtualmin 7 official gpg key if needed
   rpm -q gpg-pubkey-9d3152d3-895093ac >/dev/null 2>&1 || \
     rpm --import %{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-virtualmin-7
   # Get the serial/key from the /etc/virtualmin-license file


### PR DESCRIPTION
Removes the Webmin.com signing key. We go to some lengths to protect users from installing Webmin from Webmin.com, and instead encourage them to get it from the Virtualmin repos because it gets more testing with Virtualmin before release.

Anyone who insists on installing from Webmin.com can take the extra steps to do so.